### PR TITLE
Fix: a11y warning a11y-mouse-events-have-key-events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lottiefiles/svelte-lottie-player",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "svelte": "src/components/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",

--- a/src/components/Controls.svelte
+++ b/src/components/Controls.svelte
@@ -318,6 +318,8 @@
         class=""
         on:mouseout="{() => currentState === PlayerState.Frozen && play()}"
         on:mouseover="{() => currentState !== PlayerState.Paused && freeze()}"
+        on:blur
+        on:focus
       >
         <Popover color="#fff" on:mousewheel="{e => seek(frame + (e.deltaY > 0 ? -1 : 1))}">
           <div class="btn" slot="target">
@@ -404,6 +406,8 @@
           on:mouseover="{() => currentState !== PlayerState.Paused && freeze()}"
           on:input="{e => seek(e.target.value)}"
           on:mousewheel="{e => seek(frame + (e.deltaY > 0 ? -1 : 1))}"
+          on:blur
+          on:focus
         />
       </div>
     {:else if item === 'nextFrame'}

--- a/src/components/Popover.svelte
+++ b/src/components/Popover.svelte
@@ -84,6 +84,8 @@
   on:mousedown
   on:mouseover={show}
   on:mouseout={hide}
+  on:blur
+  on:focus
   on:mouseup
   on:mousewheel>
   <div bind:this={_triggerRef}>


### PR DESCRIPTION
When adding this library to a SvelteKit project with Vite, the following warnings are show in the console:
<img width="1514" alt="Screenshot 2022-04-14 at 10 26 12" src="https://user-images.githubusercontent.com/3987804/163345337-9316e710-e2c1-4eb4-921f-0a2955e25386.png">

Package info:
SvelteKit: v1.0.0-next.302
@lottiefiles/svelte-lottie-player: v0.2.0
