### PR TITLE
Add Svelte exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@lottiefiles/svelte-lottie-player",
   "version": "0.3.0",
   "svelte": "src/components/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./src/components/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "description": "Lottie animation player component for Svelte",


### PR DESCRIPTION
Closes #21.

The `svelte` field is deprecated. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition.