### PR TITLE
Added option to customize rendererSettings

### DIFF
--- a/src/components/LottiePlayer.svelte
+++ b/src/components/LottiePlayer.svelte
@@ -54,6 +54,9 @@
   // Renderer to use in lottie-web
   export let renderer = PlayerRender.SVG;
 
+  // To customize the renderer settings
+  export let rendererSettings = {};
+
   // Playback speed.
   export let speed = 1;
 
@@ -156,7 +159,8 @@
         preserveAspectRatio: "xMidYMid meet",
         clearCanvas: true,
         progressiveLoad: true,
-        hideOnTransparent: true
+        hideOnTransparent: true,
+        ...rendererSettings
       }
     };
 


### PR DESCRIPTION
Added the option to customize the rendererSettings.

The filterSize setting is required in order to display drop shadows correctly. 

A full list of settings can be found here:
https://github.com/airbnb/lottie-web/wiki/Renderer-Settings#filtersize-svg-renderer